### PR TITLE
Output zero-dimensional arrays instead of numbers

### DIFF
--- a/dense-numericals-src/utils/package.lisp
+++ b/dense-numericals-src/utils/package.lisp
@@ -139,6 +139,7 @@
            #:%broadcast-compatible-p
            #:broadcast-compatible-p
            #:do-with-broadcasting
+           #:array-total-offset
            #:ptr-iterate-but-inner
            #:with-simple-array-broadcast
            #:with-thresholded-multithreading/cl

--- a/dense-numericals-src/utils/package.lisp
+++ b/dense-numericals-src/utils/package.lisp
@@ -144,7 +144,9 @@
            #:with-thresholded-multithreading/cl
 
            #:out-shape-compatible-p
-           #:out-shape))
+           #:out-shape
+
+           #:ensure-array))
 
 (5am:def-suite :dense-numericals)
 

--- a/dense-numericals-src/utils/utils.lisp
+++ b/dense-numericals-src/utils/utils.lisp
@@ -75,3 +75,8 @@ or MAGICL:TENSOR for arrays with :COLUMN-MAJOR or other layouts."))
 
 (define-polymorphic-function out-shape (function-name &rest args)
   :overwrite t)
+
+(declaim (inline ensure-array))
+(defun ensure-array (element &optional shape (element-type default-element-type))
+  (make-array shape :element-type element-type
+                    :initial-element (coerce element element-type)))

--- a/dense-numericals-src/utils/utils.lisp
+++ b/dense-numericals-src/utils/utils.lisp
@@ -48,6 +48,15 @@ This is only relevant for transcendental functions which uses lparallel for mult
 the OUT argument, and/or ensuring all the appropriate arguments are
 arrays of appropriate types."))))
 
+(define-condition incompatible-broadcast-dimensions (error)
+  ((dimensions :initarg :dimensions :reader condition-dimensions)
+   (array-likes :initarg :array-likes :reader condition-array-likes))
+  (:report (lambda (c s)
+             (pprint-logical-block (s nil)
+               (format s "The following array-likes with dimensions~{~%  ~S~}~%cannot be broadcast together:~%" (condition-dimensions c))
+               (pprint-logical-block (s nil :per-line-prefix "  ")
+                 (format s "~S" (condition-array-likes c)))))))
+
 (defmacro defun* (name lambda-list &body body)
   `(eval-when (:compile-toplevel :load-toplevel :execute)
      (defun ,name ,lambda-list ,@body)))

--- a/src/utils/package.lisp
+++ b/src/utils/package.lisp
@@ -100,7 +100,9 @@
            #:with-simple-array-broadcast
 
            #:out-shape-compatible-p
-           #:out-shape))
+           #:out-shape
+
+           #:ensure-array))
 
 (5am:def-suite :numericals)
 

--- a/src/utils/utils.lisp
+++ b/src/utils/utils.lisp
@@ -276,3 +276,8 @@ Examples:
 
 (define-polymorphic-function out-shape (function-name &rest args)
   :overwrite t)
+
+(declaim (inline ensure-array))
+(defun ensure-array (element &optional shape (element-type default-element-type))
+  (make-array shape :element-type element-type
+                    :initial-element (coerce element element-type)))


### PR DESCRIPTION
This takes care of https://github.com/digikar99/numericals/issues/12 by incorporating the suggestion from https://github.com/digikar99/dense-arrays/pull/9 that outputs should always be arrays (potentially zero-dimensional) instead of numbers.

However, this requires direct changes to atleast some other places, particularly variance.lisp which uses `sum`. But for uniformity, there should also be changes to other parts of the code.

Ideally, there should be a switch to enable or disable this behavior. Or perhaps, whenever one is sure there are numbers, one can fall back to symbols in `cl:` package for performance' sake?